### PR TITLE
Switch from linked list to sequence data structure

### DIFF
--- a/DraftGen.cabal
+++ b/DraftGen.cabal
@@ -39,6 +39,7 @@ library dg-lib
   build-depends:       base ^>= 4.14.1.0
                      , aeson ^>= 1.5.6.0
                      , bytestring ^>= 0.11.1.0
+                     , containers ^>= 0.6.4.1
                      , directory ^>= 1.3.6.1
                      , filepath ^>= 1.4.2.1
                      , hashable ^>= 1.3.1.0

--- a/src/DraftGen/Encode.hs
+++ b/src/DraftGen/Encode.hs
@@ -15,6 +15,7 @@ import Control.Lens
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as S
 import Data.Maybe (fromMaybe)
+import qualified Data.Sequence as Seq
 import Types
 
 -- | Map position data and set of cards into a GameObj representing a single pack
@@ -29,9 +30,9 @@ encodePack transformObj cardSet =
       where
         updatedPackObj =
           packObj
-            & customDeck <>~ [mkCardImgObj cardObj]
-            & deckIDs <>~ [cardId]
-            & containedObjects <>~ [mkTTSCardObj cardId cardObj]
+            & customDeck %~ (Seq.|> mkCardImgObj cardObj)
+            & deckIDs %~ (Seq.|> cardId)
+            & containedObjects %~ (Seq.|> mkTTSCardObj cardId cardObj)
 
 -- | Encode list of packs into a single TTSObj
 encodePacks :: [HashSet CardObj] -> TTSObj
@@ -100,9 +101,9 @@ mkEmptyPack transformObj =
   GameObj
     { gameObjTransform = transformObj
     , gameObjName = "DeckCustom"
-    , gameObjCustomDeck = []
-    , gameObjDeckIDs = []
-    , gameObjContainedObjects = []
+    , gameObjCustomDeck = Seq.empty
+    , gameObjDeckIDs = Seq.empty
+    , gameObjContainedObjects = Seq.empty
     }
 
 defaultTTSObj :: TTSObj
@@ -112,9 +113,9 @@ defaultTTSObj =
         [ GameObj
             { gameObjTransform = packTransform
             , gameObjName = "DeckCustom"
-            , gameObjCustomDeck = []
-            , gameObjDeckIDs = []
-            , gameObjContainedObjects = []
+            , gameObjCustomDeck = Seq.empty
+            , gameObjDeckIDs = Seq.empty
+            , gameObjContainedObjects = Seq.empty
             }
         ]
     }

--- a/src/DraftGen/Types.hs
+++ b/src/DraftGen/Types.hs
@@ -15,11 +15,12 @@
 module Types where
 
 import CLI (Args (..), Ratio, Unwrapped)
-import Control.Lens hiding (Unwrapped, (.=))
+import Control.Lens hiding (Empty, Unwrapped, (.=))
 import Data.Aeson
 import Data.Char (toLower)
 import Data.HashMap.Strict as M
 import Data.Hashable (Hashable)
+import Data.Sequence (Seq (..))
 import Data.Text (pack, unpack)
 import GHC.Generics
 
@@ -138,12 +139,12 @@ instance FromJSON BulkDataObj where
       <*> v .: "name"
       <*> v .: "download_uri"
 
-toObject :: [CardImgObj] -> Value
+toObject :: Seq CardImgObj -> Value
 toObject = Object . go 1 M.empty
   where
-    go :: Int -> Object -> [CardImgObj] -> Object
-    go _ m [] = m
-    go n m (x : xs) =
+    go :: Int -> Object -> Seq CardImgObj -> Object
+    go _ m Empty = m
+    go n m (x :<| xs) =
       go (n + 1) (M.insert (pack $ show n) (toJSON x) m) xs
 
 data CardImgObj = CardImgObj
@@ -200,9 +201,9 @@ instance ToJSON TTSCardObj where
 data GameObj = GameObj
   { gameObjTransform :: TransformObj
   , gameObjName :: String
-  , gameObjCustomDeck :: [CardImgObj]
-  , gameObjDeckIDs :: [Int]
-  , gameObjContainedObjects :: [TTSCardObj]
+  , gameObjCustomDeck :: Seq CardImgObj
+  , gameObjDeckIDs :: Seq Int
+  , gameObjContainedObjects :: Seq TTSCardObj
   }
   deriving (Generic, Show)
 


### PR DESCRIPTION
Currently the core data structures representing the card objects and the TTS encoding for the packs use a linked list which we are appending to the end of. This operation is slow O(n). Therefore this update refactors the types and functions to use the Seq data structure which has constant time snoc. Fixes #1
