### PR TITLE
Use card cache for generating packs

### DIFF
--- a/src/DraftGen/File.hs
+++ b/src/DraftGen/File.hs
@@ -59,7 +59,7 @@ execute = (either print pure =<<) $
     selectedCards <- liftIO $ genPacks config cards
     _ <- liftIO $ encodeFile (dataPath </> ln) $ encodePacks $ genLands config landData
     _ <- liftIO $ encodeFile (dataPath </> pn) $ encodePacks selectedCards
-    liftIO $ printf "Packs generated at: %s and lands at: %s" (dataPath </> pn) (dataPath </> ln)
+    liftIO $ printf "Packs generated at: %s\nLands at: %s" (dataPath </> pn) (dataPath </> ln)
 
 -- | Get the latest card set from scryfall and write them to a json file
 getLatestCards :: FilePath -> FilePath -> IO (Either String (FilePath, FilePath))

--- a/src/DraftGen/File.hs
+++ b/src/DraftGen/File.hs
@@ -9,7 +9,7 @@
 -}
 module File (execute) where
 
-import CLI (Args, Unwrapped, unwrapRecord)
+import CLI (Args, Unwrapped, unwrapRecord, updateCards)
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
@@ -18,7 +18,7 @@ import qualified Data.ByteString.Lazy as B
 import Encode (encodePacks)
 import Generate (genLands, genPacks, readCards)
 import Network.Wreq (get, responseBody)
-import System.Directory (XdgDirectory (..), createDirectoryIfMissing, getXdgDirectory)
+import System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileExist, getXdgDirectory)
 import System.FilePath ((</>))
 import Text.Printf (printf)
 import Types (BulkDataObj, downloadUri, fromArgs)
@@ -48,7 +48,7 @@ execute = (either print pure =<<) $
     cachePath <- liftIO $ getXdgDirectory XdgCache appName
     _ <- liftIO $ createDirectoryIfMissing True cachePath
     (landCache, cardCache) <-
-      ExceptT $ getLatestCards (cachePath </> landCacheName) (cachePath </> cardCacheName)
+      ExceptT $ getFromCache (updateCards args) (cachePath </> landCacheName) (cachePath </> cardCacheName)
     cards <- ExceptT $ readCards cardCache
     landData <- ExceptT $ readCards landCache
     let config = fromArgs args
@@ -60,6 +60,20 @@ execute = (either print pure =<<) $
     _ <- liftIO $ encodeFile (dataPath </> ln) $ encodePacks $ genLands config landData
     _ <- liftIO $ encodeFile (dataPath </> pn) $ encodePacks selectedCards
     liftIO $ printf "Packs generated at: %s\nLands at: %s" (dataPath </> pn) (dataPath </> ln)
+
+-- | If land and card cache already exists return them unless a flush is forced otherwise fetch them from scryfall
+getFromCache :: Bool -> FilePath -> FilePath -> IO (Either String (FilePath, FilePath))
+getFromCache force landPath cardPath = paths >>= choice'
+  where
+    choice' = uncurry (choice force)
+    paths = (,) <$> doesFileExist landPath <*> doesFileExist cardPath
+    choice toForce landExists cardExists
+      | toForce = updateCache
+      | landExists && cardExists = pure $ Right (landPath, cardPath)
+      | otherwise = updateCache
+      where
+        msg = putStrLn "Updating cache..."
+        updateCache = msg *> getLatestCards landPath cardPath
 
 -- | Get the latest card set from scryfall and write them to a json file
 getLatestCards :: FilePath -> FilePath -> IO (Either String (FilePath, FilePath))

--- a/src/DraftGen/Generate.hs
+++ b/src/DraftGen/Generate.hs
@@ -14,7 +14,6 @@ module Generate (
   filterBySet,
   genLands,
   genPacks,
-  getLatestCards,
   readCards,
   S.size,
 ) where
@@ -22,34 +21,13 @@ module Generate (
 import CLI (Ratio (..))
 import Control.Lens hiding (set)
 import Control.Monad (replicateM)
-import Data.Aeson (eitherDecode, eitherDecodeFileStrict, encodeFile)
-import qualified Data.ByteString.Lazy as B
+import Data.Aeson (eitherDecodeFileStrict, encodeFile)
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as S
 import Data.List (isInfixOf, isPrefixOf)
 import Data.Maybe (isJust)
-import Network.Wreq
 import System.Random
 import Types
-
--- | Get the latest card set from scryfall and write them to a json file
-getLatestCards :: IO (Either String FilePath)
-getLatestCards = do
-  l <- get "https://api.scryfall.com/bulk-data/default-cards"
-  r <- get "https://api.scryfall.com/bulk-data/oracle-cards"
-  let eBd :: Either String BulkDataObj
-      eBd = eitherDecode $ r ^. responseBody
-      eLands :: Either String BulkDataObj
-      eLands = eitherDecode $ l ^. responseBody
-  case (eLands, eBd) of
-    (Left err, _) -> pure $ Left err
-    (_, Left err) -> pure $ Left err
-    (Right landData, Right bulkData) -> do
-      binData <- get (bulkData ^. downloadUri)
-      landBinData <- get (landData ^. downloadUri)
-      B.writeFile "data/LandData.json" (landBinData ^. responseBody)
-      B.writeFile "data/BulkData.json" (binData ^. responseBody)
-      pure $ Right "data/BulkData.json"
 
 -- | Read cards from filepath into memory
 readCards :: FilePath -> IO (Either String (HashSet CardObj))


### PR DESCRIPTION
The card cache is now used when generating card packs if the cache exists. Fixes #5
