### PR TITLE
Update CLI cache flush option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 An MTG booster pack generator for [Tabletop Simulator](https://store.steampowered.com/app/286160/Tabletop_Simulator/).
 
 # Documentation
-![options](https://i.imgur.com/6PQYoGA.png)
+![options](https://i.imgur.com/qnJC3Jx.png)
 
 DraftGen lets you generate booster packs for MTG. The default options are set to simulate the rules and drop rates of regular booster packs. The default card set to generate packs from is the latest core set. These options can be changed by passing arguments through the command line. All arguments are listed in the help section `dg --help`. DraftGen will print the paths where the resulting json files are written depending upon your platform.
 

--- a/src/DraftGen/CLI.hs
+++ b/src/DraftGen/CLI.hs
@@ -31,15 +31,12 @@ data Args w = Args
   , rares :: w ::: Int <!> "1" <?> "Amount of rares in pack (default: 1)"
   , mythicChance :: w ::: Ratio <!> "1/8" <?> "Chance of rare being mythic, value given as ratio (default: 1/8 meaning 1 in 8)"
   , foilChance :: w ::: Ratio <!> "1/45" <?> "Chance of one common being a foil of any rarity, value given as ratio (default: 1/45 meaning 1 in 45)"
-  , updateCards :: w ::: Bool <!> "False" <?> "Update card inventory by downloading the cards from scryfall (default: False)"
+  , downloadCards :: w ::: Bool <!> "False" <?> "Update card cache when generating packs"
   }
   deriving (Generic)
 
 modifiers :: Modifiers
-modifiers =
-  defaultModifiers
-    { shortNameModifier = firstLetter
-    }
+modifiers = lispCaseModifiers {shortNameModifier = firstLetter}
 
 instance ParseRecord (Args Wrapped) where
   parseRecord = parseRecordWithModifiers modifiers

--- a/src/DraftGen/File.hs
+++ b/src/DraftGen/File.hs
@@ -53,7 +53,7 @@ execute = (either print pure =<<) $
     cachePath <- liftIO $ getXdgDirectory XdgCache appName
     _ <- liftIO $ createDirectoryIfMissing True cachePath
     cardCache <-
-      ExceptT $ getFromCache (updateCards args) (cachePath </> cardCacheName)
+      ExceptT $ getFromCache (downloadCards args) (cachePath </> cardCacheName)
     cards <- ExceptT $ readCards cardCache
     landData <- ExceptT $ readCards cardCache
     let config = fromArgs args


### PR DESCRIPTION
Change cache update flag name so that the shorthand doesn't collide with other options.
