### PR TITLE
increase cardgen performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cabal.project.local~
 .ghc.environment.*
 data/
 test_runs/
+dg.svg

--- a/DraftGen.cabal
+++ b/DraftGen.cabal
@@ -65,6 +65,7 @@ library
 
   build-depends:
     , aeson
+    , async
     , base                  ^>=4.19.2.0
     , bytestring
     , containers
@@ -79,6 +80,9 @@ library
     , random
     , transformers
     , unordered-containers
+
+  other-modules:
+    Paths_DraftGen
 
   hs-source-dirs:  src/DraftGen
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 An MTG booster pack generator for [Tabletop Simulator](https://store.steampowered.com/app/286160/Tabletop_Simulator/).
 
 # Documentation
-![options](https://i.imgur.com/WDUyeUa.png)
+Use `--help` for documentation.
 
 DraftGen lets you generate booster packs for MTG. The default options are set to simulate the rules and drop rates of regular booster packs. The default card set to generate packs from is the latest core set. These options can be changed by passing arguments through the command line. All arguments are listed in the help section `dg --help`. DraftGen will print the paths where the resulting json files are written depending upon your platform.
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,18 +46,20 @@
         };
         devShells.default = let
           hpkgs = pkgs.haskell.packages.ghc98;
-          tools = with hpkgs; [
-            cabal-fmt
-            cabal-install
-            fourmolu
-            ghc
-            ghc-prof-flamegraph
-            ghcid
-            profiteur
-          ] ++ (with pkgs; [
-            haskell-language-server
-            nixd
-          ]);
+          tools = with hpkgs;
+            [
+              cabal-fmt
+              cabal-install
+              fourmolu
+              ghc
+              ghc-prof-flamegraph
+              ghcid
+              profiteur
+            ]
+            ++ (with pkgs; [
+              haskell-language-server
+              nixd
+            ]);
           libraries = [
             pkgs.zlib
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,11 @@
             ghc
             ghc-prof-flamegraph
             ghcid
-            pkgs.haskell-language-server
-            pkgs.nixd
             profiteur
-          ];
+          ] ++ (with pkgs; [
+            haskell-language-server
+            nixd
+          ]);
           libraries = [
             pkgs.zlib
           ];

--- a/profile.sh
+++ b/profile.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+
+GHC_PROFILING_FLAGS="-fprof-auto -rtsopts"
+
+cabal build --enable-profiling --ghc-options="$GHC_PROFILING_FLAGS"
+
+time ./dist-newstyle/build/x86_64-linux/ghc-9.8.4/DraftGen-1.5.2.0/x/dg/build/dg/dg +RTS -p -RTS "$@"
+
+ghc-prof-flamegraph dg.prof
+
+firefox dg.svg

--- a/src/DraftGen/CLI.hs
+++ b/src/DraftGen/CLI.hs
@@ -45,7 +45,6 @@ data Args w = Args
   , mythicChance :: w ::: Ratio <!> "1/8" <?> "Chance of rare being mythic, value given as ratio"
   , foilChance :: w ::: Ratio <!> "1/45" <?> "Chance of one common being a foil of any rarity, value given as ratio (where 1/45 means 1 in 45)"
   , downloadCards :: w ::: Bool <!> "False" <?> "Update card cache when generating packs"
-  , getCard :: w ::: Maybe String <?> "Ignores all other arguments and generates a pack containing the one specific card"
   }
   deriving stock (Generic)
 

--- a/src/DraftGen/CLI.hs
+++ b/src/DraftGen/CLI.hs
@@ -44,7 +44,6 @@ data Args w = Args
   , rares :: w ::: Int <!> "1" <?> "Amount of rares in pack"
   , mythicChance :: w ::: Ratio <!> "1/8" <?> "Chance of rare being mythic, value given as ratio"
   , foilChance :: w ::: Ratio <!> "1/45" <?> "Chance of one common being a foil of any rarity, value given as ratio (where 1/45 means 1 in 45)"
-  , downloadCards :: w ::: Bool <!> "False" <?> "Update card cache when generating packs"
   }
   deriving stock (Generic)
 

--- a/src/DraftGen/Types.hs
+++ b/src/DraftGen/Types.hs
@@ -54,7 +54,6 @@ import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import GHC.Generics (Generic)
 import Text.Printf (printf)
-
 import Util (packName, snakeCase)
 
 data PackConfig = PackConfig
@@ -67,7 +66,6 @@ data PackConfig = PackConfig
   , foilChance :: Ratio
   }
   deriving stock (Generic, Show)
-
 
 -- | Produce filename with set and pack amount information
 fileName :: PackConfig -> String -> String
@@ -88,7 +86,7 @@ data Rarity = Common | Uncommon | Rare | Mythic | Special | Bonus
 instance Hashable Rarity
 
 instance ToJSON Rarity where
-  toJSON = genericToJSON defaultOptions { constructorTagModifier = toLowerCase }
+  toJSON = genericToJSON defaultOptions {constructorTagModifier = toLowerCase}
 
 instance FromJSON Rarity where
   parseJSON =
@@ -164,7 +162,7 @@ data CardFace = CardFace
   deriving anyclass (Hashable)
 
 instance ToJSON CardFace where
-  toJSON = genericToJSON defaultOptions { fieldLabelModifier = snakeCase }
+  toJSON = genericToJSON defaultOptions {fieldLabelModifier = snakeCase}
 
 instance FromJSON CardFace where
   parseJSON = withObject "CardFace" $ \v ->
@@ -199,9 +197,11 @@ instance Eq CardObj where
     cardObjA.name == cardObjB.name
 
 instance ToJSON CardObj where
-  toJSON = genericToJSON defaultOptions
-    { fieldLabelModifier = snakeCase
-    }
+  toJSON =
+    genericToJSON
+      defaultOptions
+        { fieldLabelModifier = snakeCase
+        }
 
 instance FromJSON CardObj where
   parseJSON = withObject "CardObj" $ \v ->
@@ -239,13 +239,15 @@ instance ToJSON BorderColor where
   toJSON =
     genericToJSON
       defaultOptions
-      { constructorTagModifier = toLowerCase . drop 5 }
+        { constructorTagModifier = toLowerCase . drop 5
+        }
 
 instance FromJSON BorderColor where
   parseJSON =
     genericParseJSON
       defaultOptions
-        { constructorTagModifier = toLowerCase . drop 5 }
+        { constructorTagModifier = toLowerCase . drop 5
+        }
 
 data BulkDataObj = BulkDataObj
   { id :: String
@@ -264,18 +266,18 @@ instance FromJSON BulkDataObj where
       <*> v .: "download_uri"
 
 data SetInfo = SetInfo
-  { id :: String,
-    code :: String,
-    searchUri :: String,
-    releasedAt :: String,
-    setType :: String,
-    cardCount:: Int
+  { id :: String
+  , code :: String
+  , searchUri :: String
+  , releasedAt :: String
+  , setType :: String
+  , cardCount :: Int
   }
   deriving stock (Generic, Show)
 
-instance FromJSON SetInfo  where
+instance FromJSON SetInfo where
   parseJSON = withObject "SetInfo" $ \v ->
-     SetInfo
+    SetInfo
       <$> v .: "id"
       <*> v .: "code"
       <*> v .: "search_uri"
@@ -298,7 +300,6 @@ instance FromJSON SetDataObj where
       <*> v .: "total_cards"
       <*> v .: "has_more"
       <*> v .: "data"
-
 
 toObject :: Seq CardImgObj -> Value
 toObject = Object . go 1 M.empty

--- a/src/DraftGen/Types.hs
+++ b/src/DraftGen/Types.hs
@@ -74,7 +74,7 @@ fileName cfg name
   | otherwise = printf "%s%s.json" cfg.set name
 
 fromArgs :: Args Unwrapped -> PackConfig
-fromArgs (Args s a c uc r mc fc _) = PackConfig a s c uc r mc fc
+fromArgs (Args s a c uc r mc fc) = PackConfig a s c uc r mc fc
 
 -- Lowercase string
 toLowerCase :: String -> String

--- a/src/DraftGen/Util.hs
+++ b/src/DraftGen/Util.hs
@@ -10,16 +10,29 @@
 module Util
   ( appName
   , cardCacheName
-  , fileName
   , landName
   , packName
+  , snakeCase
   , tokenName
   )
 where
 
-import Text.Printf (printf)
-import Types (PackConfig)
-import Types qualified
+import Data.Char
+
+snakeCase :: String -> String
+snakeCase =  symbCase '_'
+
+-- | Generic casing for symbol separated names
+symbCase :: Char -> (String -> String)
+symbCase sym =  u . applyFirst toLower
+  where u []                       = []
+        u (x:xs) | isUpper x = sym : toLower x : u xs
+                 | otherwise = x : u xs
+
+applyFirst :: (Char -> Char) -> String -> String
+applyFirst _ []     = []
+applyFirst f [x]    = [f x]
+applyFirst f (x:xs) = f x: xs
 
 appName :: FilePath
 appName = "DraftGen"
@@ -35,9 +48,3 @@ packName = "packs"
 
 tokenName :: FilePath
 tokenName = "tokens"
-
--- | Produce filename with set and pack amount information
-fileName :: PackConfig -> String -> String
-fileName cfg name
-  | name == packName = printf "%d%s%s.json" cfg.amount cfg.set name
-  | otherwise = printf "%s%s.json" cfg.set name

--- a/src/DraftGen/Util.hs
+++ b/src/DraftGen/Util.hs
@@ -20,19 +20,21 @@ where
 import Data.Char
 
 snakeCase :: String -> String
-snakeCase =  symbCase '_'
+snakeCase = symbCase '_'
 
 -- | Generic casing for symbol separated names
 symbCase :: Char -> (String -> String)
-symbCase sym =  u . applyFirst toLower
-  where u []                       = []
-        u (x:xs) | isUpper x = sym : toLower x : u xs
-                 | otherwise = x : u xs
+symbCase sym = u . applyFirst toLower
+ where
+  u [] = []
+  u (x : xs)
+    | isUpper x = sym : toLower x : u xs
+    | otherwise = x : u xs
 
 applyFirst :: (Char -> Char) -> String -> String
-applyFirst _ []     = []
-applyFirst f [x]    = [f x]
-applyFirst f (x:xs) = f x: xs
+applyFirst _ [] = []
+applyFirst f [x] = [f x]
+applyFirst f (x : xs) = f x : xs
 
 appName :: FilePath
 appName = "DraftGen"


### PR DESCRIPTION
by querying the scryfall API for sets instead
of downloading every MTG card every time the cache needs to be refreshed.